### PR TITLE
Allow Problem Update When User Re-attempts Completed or Rejected Problem

### DIFF
--- a/client/app/NavBar.js
+++ b/client/app/NavBar.js
@@ -5,7 +5,7 @@ import { useAppContext } from "./context"
 import { useEffect } from "react";
 
 export default function NavBar(){
-    const {id, uid, setId, setUid, setData, setValue, setChallenge} = useAppContext()
+    const {id, uid, setId, setUid, setData, setValue, setChallenge, clearAll} = useAppContext()
 
     useEffect(() => {
         if (id && uid) {
@@ -35,7 +35,7 @@ export default function NavBar(){
                     <section className="flex items-center gap-5">
                         <NavbarLink href="/challenge" className="text-lg">Code Challenge</NavbarLink>
                         <NavbarLink  href="/userSettings" className="text-lg">Settings</NavbarLink>
-                        <NavbarLink  href="/" onClick={(e) => { setId(null); setUid(null); setValue(''); setData([]); setChallenge('')}} className="text-lg"> Sign out </NavbarLink>
+                        <NavbarLink  href="/" onClick={(e) => {clearAll();}} className="text-lg"> Sign out </NavbarLink>
                         <Avatar alt="User Profile Image" img="/Profile.png"/>
                     </section>
                 </NavbarCollapse>

--- a/client/app/challenge/Answer.js
+++ b/client/app/challenge/Answer.js
@@ -5,7 +5,7 @@ import { Button } from 'flowbite-react'
 import { deleteCompleted, updateQuestion, deleteRejected } from 'utils/validation'
 
 export default function Answer() {
-    const { id, data, value, setValue, setData, challenge, status, name, problem } = useAppContext()
+    const { id, data, value, setValue, setData, challenge, status, name, problem, setStatus} = useAppContext()
     const [result, setResult] = useState([])
 
     const getAnswer = async() => {
@@ -27,6 +27,7 @@ export default function Answer() {
             setResult(resultData.isCorrect)
             const evaluation = resultData.breakdown.join('\n');
             setValue(evaluation)
+            console.log(resultData)
             alert("Evaluation successful.")
         } catch (error) {
             alert(error+ " Try again!")
@@ -37,12 +38,14 @@ export default function Answer() {
         if (status === false && result === true) {
             updateQuestion(id, problem, name, result);
             deleteRejected(id, problem);
-            console.log(id, problem, name, result);
+            setStatus('')
         } else if (status === true && result === false) {
             updateQuestion(id, problem, name, result);
             deleteCompleted(id, problem);
-        } else if (status === undefined || status === null) {
-            addQuestion();
+            setStatus('')
+        } else if (!status) {
+            addQuestion(id, data.Name, data.Challenge, result);
+        }else {
         }
     };
 

--- a/client/app/challenge/Answer.js
+++ b/client/app/challenge/Answer.js
@@ -2,9 +2,10 @@
 import { useState } from 'react'
 import { useAppContext } from 'components/context'
 import { Button } from 'flowbite-react'
+import { deleteCompleted, updateQuestion, deleteRejected } from 'utils/validation'
 
 export default function Answer() {
-    const { id, data, value, setValue, setData, challenge } = useAppContext()
+    const { id, data, value, setValue, setData, challenge, status, name, problem } = useAppContext()
     const [result, setResult] = useState([])
 
     const getAnswer = async() => {
@@ -32,6 +33,19 @@ export default function Answer() {
         }
     }
 
+    const saveQuestion = async () => {
+        if (status === false && result === true) {
+            updateQuestion(id, problem, name, result);
+            deleteRejected(id, problem);
+            console.log(id, problem, name, result);
+        } else if (status === true && result === false) {
+            updateQuestion(id, problem, name, result);
+            deleteCompleted(id, problem);
+        } else if (status === undefined || status === null) {
+            addQuestion();
+        }
+    };
+
     const addQuestion = async () => {
         try {
             const res = await fetch ("https://backendcodechallenge.vercel.app/addProblem", {
@@ -56,7 +70,7 @@ export default function Answer() {
     return (
         <>
             <Button  className="text-lg bg-purple-950" onClick={getAnswer}> Evaluate </Button>
-            <Button className="text-lg bg-pink-700" onClick={addQuestion}> Save Question </Button>
+            <Button className="text-lg bg-pink-700" onClick={saveQuestion}> Save Question </Button>
         </>
     )
 }

--- a/client/app/context/index.js
+++ b/client/app/context/index.js
@@ -13,6 +13,8 @@ export function AppWrapper({ children }) {
     const [loading, setLoading] =useState('');
     const [search, setSearch] =useState('');
     const [status, setStatus] = useState('');
+    const [name, setName] = useState('');
+    const [problem, setProblem] = useState('');
 
 
     useEffect(() => {
@@ -24,7 +26,9 @@ export function AppWrapper({ children }) {
         const storedError = localStorage.getItem('error');
         const storedLoading = localStorage.getItem('loading');
         const storedSearch  = localStorage.getItem('search');
-        const storedStatus = localStorage.getItem('status')
+        const storedStatus = localStorage.getItem('status');
+        const storedName = localStorage.getItem('name');
+        const storedProblem = localStorage.getItem('problem');
         if (storedId) setId(Number(storedId));
         if (storedUid) setUid(storedUid);
         if (storedValue) setValue(storedValue);
@@ -33,7 +37,9 @@ export function AppWrapper({ children }) {
         if (storedError) setError(storedError);
         if (storedLoading) setLoading(storedLoading);
         if (storedSearch) setSearch(storedSearch);
-        if (storedStatus) setStatus(storedStatus)
+        if (storedStatus) setStatus(storedStatus);
+        if (storedName) setName(storedName);
+        if (storedProblem) setProblem (storedProblem);
 
     }, []);
 
@@ -47,10 +53,12 @@ export function AppWrapper({ children }) {
         localStorage.setItem('loading', loading);
         localStorage.setItem('search', search);
         localStorage.setItem('status', status);
-    }, [id, uid, data, value, challenge, error, loading, search, status]);
+        localStorage.setItem('name', name);
+        localStorage.setItem('problem', problem);
+    }, [id, uid, data, value, challenge, error, loading, search, status, name, problem]);
 
     return (
-        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch, status, setStatus}}>
+        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch, status, setStatus, name, setName, problem, setProblem}}>
             {children}
         </AppContext.Provider>
     );

--- a/client/app/context/index.js
+++ b/client/app/context/index.js
@@ -57,8 +57,34 @@ export function AppWrapper({ children }) {
         localStorage.setItem('problem', problem);
     }, [id, uid, data, value, challenge, error, loading, search, status, name, problem]);
 
+    const clearAll = () => {
+        setId(null);
+        setUid(null);
+        setData([]);
+        setValue('');
+        setChallenge('');
+        setError('');
+        setLoading('');
+        setSearch('');
+        setStatus('');
+        setName('');
+        setProblem('');
+
+        localStorage.removeItem('id');
+        localStorage.removeItem('uid');
+        localStorage.removeItem('data');
+        localStorage.removeItem('value');
+        localStorage.removeItem('challenge');
+        localStorage.removeItem('error');
+        localStorage.removeItem('loading');
+        localStorage.removeItem('search');
+        localStorage.removeItem('status');
+        localStorage.removeItem('name');
+        localStorage.removeItem('problem');
+    };
+
     return (
-        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch, status, setStatus, name, setName, problem, setProblem}}>
+        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch, status, setStatus, name, setName, problem, setProblem, clearAll}}>
             {children}
         </AppContext.Provider>
     );

--- a/client/app/context/index.js
+++ b/client/app/context/index.js
@@ -12,6 +12,7 @@ export function AppWrapper({ children }) {
     const [error, setError] = useState('');
     const [loading, setLoading] =useState('');
     const [search, setSearch] =useState('');
+    const [status, setStatus] = useState('');
 
 
     useEffect(() => {
@@ -23,6 +24,7 @@ export function AppWrapper({ children }) {
         const storedError = localStorage.getItem('error');
         const storedLoading = localStorage.getItem('loading');
         const storedSearch  = localStorage.getItem('search');
+        const storedStatus = localStorage.getItem('status')
         if (storedId) setId(Number(storedId));
         if (storedUid) setUid(storedUid);
         if (storedValue) setValue(storedValue);
@@ -30,7 +32,8 @@ export function AppWrapper({ children }) {
         if (storedChallenge) setChallenge(storedChallenge);
         if (storedError) setError(storedError);
         if (storedLoading) setLoading(storedLoading);
-        if (storedSearch) setLoading(storedSearch);
+        if (storedSearch) setSearch(storedSearch);
+        if (storedStatus) setStatus(storedStatus)
 
     }, []);
 
@@ -43,10 +46,11 @@ export function AppWrapper({ children }) {
         localStorage.setItem('error', error);
         localStorage.setItem('loading', loading);
         localStorage.setItem('search', search);
-    }, [id, uid, data, value, challenge, error, loading, search]);
+        localStorage.setItem('status', status);
+    }, [id, uid, data, value, challenge, error, loading, search, status]);
 
     return (
-        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch}}>
+        <AppContext.Provider value={{ id, setId, uid, setUid, data, setData, value, setValue, challenge, setChallenge, error, setError, loading, setLoading, search, setSearch, status, setStatus}}>
             {children}
         </AppContext.Provider>
     );

--- a/client/app/userSettings/completed/page.js
+++ b/client/app/userSettings/completed/page.js
@@ -2,11 +2,11 @@
 import { useAppContext } from "components/context";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, TextInput, Pagination} from "flowbite-react"
+import { Button, TextInput, Pagination} from "flowbite-react";
+import { deleteCompleted } from "utils/validation";
 
 export default function Completed(){
-    const { id, data, setData, setChallenge } = useAppContext();
-    const [name, setName] = useState('');
+    const { id, data, setData, setChallenge, setStatus, name, setName, setProblem} = useAppContext();
     const [editingId, setEditingId] = useState(null);
     const [currentPage, setCurrentPage] = useState(1);
     const [totalPage, setTotalPage] = useState(1);
@@ -28,6 +28,7 @@ export default function Completed(){
                     }
                 );
                 const result = await response.json();
+                console.log(result)
                 setData(result.data);
                 setTotalPage(result.pagination ? result.pagination.total_pages : 1);
             } catch (error) {
@@ -39,6 +40,10 @@ export default function Completed(){
 
     function getChallenge(item) {
         setChallenge(item[3]);
+        setStatus(true);
+        setProblem(item[0])
+        setName(item[2]);
+
         router.push("/challenge");
     }
 
@@ -67,29 +72,13 @@ export default function Completed(){
         }
     }
 
-    async function deleteCompleted(id, completed_id){
-
-        try {
-            const response = await fetch ("https://backendcodechallenge.vercel.app/deleteCompleted", {
-                method: "DELETE",
-                headers: {
-                    "content-type": "application/json"
-                },
-                body: JSON.stringify({
-                    user_id: id,
-                    completed_id: completed_id
-                })
-            })
-            const result = await response.json()
-            alert(result.message)
-            setName('')
-            window.location.reload();
-            return console.log(result)
-        } catch (error) {
-            alert(error)
-        }
+    function getChallenge(item) {
+        setChallenge(item[3]);
+        setStatus(true);
+        setProblem(item[0]);
+        setName(item[2]);
+        router.push("/challenge");
     }
-
     return (
         <div>
             <section className="bg-white mx-15 p-10 border-2 border-black">

--- a/client/app/userSettings/favorite/page.js
+++ b/client/app/userSettings/favorite/page.js
@@ -18,7 +18,7 @@ export default function favoritePage(){
         if (!id) return;
         async function getFavorites(){
             try {
-                const response = await fetch (`https://backendcodechallenge.vercel.app/getFavorite?user_id=${id}`, {
+                const response = await fetch (`https://backendcodechallenge.vercel.app/getFavorite?user_id=${id}&page=${currentPage}`, {
                     method: "GET",
                     headers: {
                         "content-type": "application/json"

--- a/client/app/userSettings/rejected/page.js
+++ b/client/app/userSettings/rejected/page.js
@@ -3,11 +3,11 @@
 import { useAppContext } from "components/context";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, TextInput, Pagination} from "flowbite-react"
+import { Button, TextInput, Pagination} from "flowbite-react";
+import { deleteRejected } from "utils/validation";
 
 export default function RejectedProblem() {
-    const { id, data, setData, setChallenge } = useAppContext();
-    const [name, setName] = useState('');
+    const { id, data, setData, setChallenge, setStatus, setProblem, setName, name} = useAppContext();
     const [editingId, setEditingId] = useState(null);
     const [currentPage, setCurrentPage] = useState(1);
     const [totalPage, setTotalPage] = useState(1);
@@ -43,6 +43,9 @@ export default function RejectedProblem() {
 
     function getChallenge(item) {
         setChallenge(item[3]);
+        setStatus(false);
+        setProblem(item[0]);
+        setName(item[2]);
         router.push("/challenge");
     }
 
@@ -69,28 +72,6 @@ export default function RejectedProblem() {
             window.location.reload();
             setName('')
         } catch (error){
-            alert(error)
-        }
-    }
-
-    async function deleteRejected(id, rejected_id){
-
-        try {
-            const response = await fetch ("https://backendcodechallenge.vercel.app/deleteRejected", {
-                method: "DELETE",
-                headers: {
-                    "content-type": "application/json"
-                },
-                body: JSON.stringify({
-                    user_id: id,
-                    rejected_id: rejected_id
-                })
-            })
-            const result = await response.json()
-            alert(result.message)
-            window.location.reload();
-            setName('')
-        } catch (error) {
             alert(error)
         }
     }

--- a/client/utils/validation.js
+++ b/client/utils/validation.js
@@ -55,7 +55,6 @@ export async function deleteRejected(id, rejected_id){
             })
         })
         const result = await response.json()
-        alert(result.message)
         window.location.reload();
     } catch (error) {
         alert(error)
@@ -75,7 +74,6 @@ export async function deleteCompleted(id, completed_id){
             })
         })
         const result = await response.json()
-        alert(result.message)
         window.location.reload();
         return console.log(result)
     } catch (error) {

--- a/client/utils/validation.js
+++ b/client/utils/validation.js
@@ -23,3 +23,62 @@ export async function addFavorites(id, favorite_problems){
         console.log(error)
     }
 }
+
+export async function updateQuestion(user_id, id, name, is_correct){
+
+    try {
+        const response = await fetch ("https://backendcodechallenge.vercel.app/updateProblem", {
+            method: "PUT",
+            headers: {
+                "content-type": "application/json"
+            },
+            body: JSON.stringify({user_id: user_id, id: id, name: name, is_correct: is_correct})
+        })
+        const result = await response.json()
+        alert("Updated Question")
+    } catch (error) {
+        console.log(error)
+    }
+}
+
+export async function deleteRejected(id, rejected_id){
+
+    try {
+        const response = await fetch ("https://backendcodechallenge.vercel.app/deleteRejected", {
+            method: "DELETE",
+            headers: {
+                "content-type": "application/json"
+            },
+            body: JSON.stringify({
+                user_id: id,
+                rejected_id: rejected_id
+            })
+        })
+        const result = await response.json()
+        alert(result.message)
+        window.location.reload();
+    } catch (error) {
+        alert(error)
+    }
+}
+export async function deleteCompleted(id, completed_id){
+
+    try {
+        const response = await fetch ("https://backendcodechallenge.vercel.app/deleteCompleted", {
+            method: "DELETE",
+            headers: {
+                "content-type": "application/json"
+            },
+            body: JSON.stringify({
+                user_id: id,
+                completed_id: completed_id
+            })
+        })
+        const result = await response.json()
+        alert(result.message)
+        window.location.reload();
+        return console.log(result)
+    } catch (error) {
+        alert(error)
+    }
+}

--- a/server/GPT.py
+++ b/server/GPT.py
@@ -29,12 +29,7 @@ def generateCodeChallenge():
                     "Type": "Array"
                     "Input": "{insert input}.",
                     "Output": "{insert output}",
-                    "Constraints": "{insert constraints}",
-                    "Test Cases": [
-                        {"test_case": "evenNumbers([1, 2, 3, 4, 5, 6]), expected:[2, 4, 6]"},
-                        {"test_case": "evenNumbers([10, 15, 20, 25]), expected:[10, 20]"},
-                        {"test_case": "evenNumbers([]), expected: []"}
-                    ]
+                    "Constraints": "{insert constraints}"
                     }
 
                     Please ensure that the generated JSON file. Return only raw JSON, no markdown, no preamble, no explanation.

--- a/server/GPT.py
+++ b/server/GPT.py
@@ -17,8 +17,9 @@ def generateCodeChallenge():
                 "role": "user",
                 "content":  """
                     Generate a short and concise coding challenge suitable for a Junior or Entry-Level software engineer.
-                    The challenge should involve any data type such as integers, strings, arrays, or other common data structures.
-                    The problem should cover a variety of topics and not focus solely on strings.
+                    The challenge should involve any of the following: integers, strings, arrays, dictionaries, sets, or simple algorithms (sorting, counting, etc).
+                    Do not generate questions focused only on strings. Vary topics such as loops, conditionals, and simple algorithms.
+
 
 
                     Here’s an example of how the response should be structured in JSON format:
@@ -26,14 +27,12 @@ def generateCodeChallenge():
                     {
                     "Challenge": "{insert Challenge}",
                     "Name": "{insert name}",
-                    "Type": "Array"
                     "Input": "{insert input}.",
                     "Output": "{insert output}",
                     "Constraints": "{insert constraints}"
                     }
 
-                    Please ensure that the generated JSON file. Return only raw JSON, no markdown, no preamble, no explanation.
-
+                    Only return valid JSON. Do not include markdown formatting, comments, or extra explanation.
                 """
             }
         ]
@@ -47,8 +46,8 @@ def evaluateProblem(challenge, answer):
     completion = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{
-                "role": "developer",
-                "content": "You are the best developer and code challenge evaluator."
+                "role": "system",
+                "content": "You are a strict code challenge evaluator. Only return valid JSON. Do not use markdown or extra commentary."
             },
             {
                 "role": "user",
@@ -74,7 +73,7 @@ def evaluateProblem(challenge, answer):
                         "Step 5: Description of evaluation step 5"
                     ]
                 }}
-                Please ensure that the breakdown explains in clear steps why the answer is correct or incorrect.
+                Only return raw JSON. No markdown, no extra explanation, no preamble.
                 """
             }
         ]

--- a/server/questions.py
+++ b/server/questions.py
@@ -91,6 +91,11 @@ def updateProblem():
         status = "COMPLETED" if is_correct == True else "REJECTED"
         updateStatus(user_id, id, status)
 
+        if is_correct == True:
+            addCompleted(user_id, id)
+        else:
+            addRejected(user_id, id)
+
         cursor.close()
         connection.close()
         return jsonify({"message": "Problem updated successfully"}), 200


### PR DESCRIPTION
### Summary

This PR enhances the problem tracking logic to allow users to **update** a previously **completed** or **rejected** problem when they choose to re-attempt it.

### Changes Made

- Detects if a user re-attempts a problem with status `completed` or `rejected`.
- Updates the existing problem record instead of creating a new one.

### Video 


https://github.com/user-attachments/assets/7b646548-9565-4c68-b045-06f994966a84


